### PR TITLE
Remove unneeded usings and dispose Font member

### DIFF
--- a/GW Codex Generator/Challenge UI/BinaryChallenges.cs
+++ b/GW Codex Generator/Challenge UI/BinaryChallenges.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Challenge_UI

--- a/GW Codex Generator/Challenge UI/IChallengeToHTML.cs
+++ b/GW Codex Generator/Challenge UI/IChallengeToHTML.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace GW_Codex_Generator.Challenge_UI
+﻿namespace GW_Codex_Generator.Challenge_UI
 {
     interface IChallengeToHTML
     {

--- a/GW Codex Generator/Challenge UI/MandatorySkillsUI.cs
+++ b/GW Codex Generator/Challenge UI/MandatorySkillsUI.cs
@@ -1,11 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Challenge_UI

--- a/GW Codex Generator/Challenge UI/RequiredElites.cs
+++ b/GW Codex Generator/Challenge UI/RequiredElites.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Challenge_UI

--- a/GW Codex Generator/Challenge UI/RequiredSkill.cs
+++ b/GW Codex Generator/Challenge UI/RequiredSkill.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Challenge_UI

--- a/GW Codex Generator/Challenge UI/TemplateChallengeUI.cs
+++ b/GW Codex Generator/Challenge UI/TemplateChallengeUI.cs
@@ -1,11 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Challenge_UI

--- a/GW Codex Generator/Challenge UI/TemplateDisplay.cs
+++ b/GW Codex Generator/Challenge UI/TemplateDisplay.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Challenge_UI

--- a/GW Codex Generator/Challenges.cs
+++ b/GW Codex Generator/Challenges.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GW_Codex_Generator
 {

--- a/GW Codex Generator/Codex Method Settings/AttributeBalanced.cs
+++ b/GW Codex Generator/Codex Method Settings/AttributeBalanced.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Codex_Method_Settings

--- a/GW Codex Generator/Codex Method Settings/ByRating.cs
+++ b/GW Codex Generator/Codex Method Settings/ByRating.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Codex_Method_Settings

--- a/GW Codex Generator/Codex Method Settings/ICodexPoolSettingsGenerator.cs
+++ b/GW Codex Generator/Codex Method Settings/ICodexPoolSettingsGenerator.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace GW_Codex_Generator.Codex_Method_Settings
 {

--- a/GW Codex Generator/Codex Method Settings/ProfessionBalanced.cs
+++ b/GW Codex Generator/Codex Method Settings/ProfessionBalanced.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Codex_Method_Settings

--- a/GW Codex Generator/Codex Method Settings/PureRandomMethod.cs
+++ b/GW Codex Generator/Codex Method Settings/PureRandomMethod.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Codex_Method_Settings

--- a/GW Codex Generator/Codex Method Settings/RegularFromAttributesElitesFromProfession.cs
+++ b/GW Codex Generator/Codex Method Settings/RegularFromAttributesElitesFromProfession.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Codex_Method_Settings

--- a/GW Codex Generator/CodexGenerator.cs
+++ b/GW Codex Generator/CodexGenerator.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GW_Codex_Generator
 {

--- a/GW Codex Generator/Form1.cs
+++ b/GW Codex Generator/Form1.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator

--- a/GW Codex Generator/GrabBag.cs
+++ b/GW Codex Generator/GrabBag.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace GW_Codex_Generator
 {

--- a/GW Codex Generator/Program.cs
+++ b/GW Codex Generator/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator

--- a/GW Codex Generator/Properties/AssemblyInfo.cs
+++ b/GW Codex Generator/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/GW Codex Generator/Skill UI/SkillDisplay.cs
+++ b/GW Codex Generator/Skill UI/SkillDisplay.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Skill_UI

--- a/GW Codex Generator/Skill UI/SkillInfoDisplay.Designer.cs
+++ b/GW Codex Generator/Skill UI/SkillInfoDisplay.Designer.cs
@@ -16,7 +16,15 @@
             if (disposing && (components != null))
             {
                 components.Dispose();
+                components = null;
             }
+
+            if(disposing && (NameFont != null))
+            {
+                NameFont.Dispose();
+                NameFont = null;
+            }
+
             base.Dispose(disposing);
         }
 

--- a/GW Codex Generator/Skill UI/SkillInfoDisplay.cs
+++ b/GW Codex Generator/Skill UI/SkillInfoDisplay.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator.Skill_UI

--- a/GW Codex Generator/Skill.cs
+++ b/GW Codex Generator/Skill.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Drawing;
 
 namespace GW_Codex_Generator

--- a/GW Codex Generator/SkillDatabase.cs
+++ b/GW Codex Generator/SkillDatabase.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GW_Codex_Generator
 {

--- a/GW Codex Generator/TemplateReaderDisplay.cs
+++ b/GW Codex Generator/TemplateReaderDisplay.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GW_Codex_Generator


### PR DESCRIPTION
Some good old Visual Studio Code Analysis cleanup for fun. Removes unused "using" directives, and adds a bit of code to dispose of a Font member that was not being disposed properly in "GW Codex Generator/Skill UI/SkillInfoDisplay.Designer.cs".